### PR TITLE
Chatmaild metrics: fix counting logic

### DIFF
--- a/chatmaild/src/chatmaild/metrics.py
+++ b/chatmaild/src/chatmaild/metrics.py
@@ -11,6 +11,8 @@ def main(vmail_dir=None):
     ci_accounts = 0
 
     for path in Path(vmail_dir).iterdir():
+        if not path.is_dir() or not (path / "cur").is_dir():
+            continue
         accounts += 1
         if path.name[:3] in ("ci-", "ac_"):
             ci_accounts += 1


### PR DESCRIPTION
Ensure the candidates for possible accounts are directories with a "cur" subdir to ensure it is a real maildir