### PR TITLE
[Nginx] Limit the bind for the HTTPS server on 8443 to 127.0.0.1

### DIFF
--- a/cmdeploy/src/cmdeploy/nginx/nginx.conf.j2
+++ b/cmdeploy/src/cmdeploy/nginx/nginx.conf.j2
@@ -46,10 +46,7 @@ http {
 
 	server {
   
-		listen 8443 ssl default_server;
-		{% if not disable_ipv6 %}
-		listen [::]:8443 ssl default_server;
-		{% endif %}
+		listen 127.0.0.1:8443 ssl default_server;
 
 		root /var/www/html;
 


### PR DESCRIPTION
I don't see any reason why 8443 should need to be exposed or what benefit there is to binding to IPv6 here when it's always proxied to on 127.0.0.1