### PR TITLE
Limit the bind for the HTTPS server on 8443 to 127.0.0.1 (additional)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## untagged
 
+- Limit the bind for the HTTPS server on 8443 to 127.0.0.1 
+  ([#522](https://github.com/chatmail/server/pull/522))
+  ([#532](https://github.com/chatmail/server/pull/532))
+
 - Send SNI when connecting to outside servers
   ([#524](https://github.com/chatmail/server/pull/524))
 

--- a/cmdeploy/src/cmdeploy/nginx/nginx.conf.j2
+++ b/cmdeploy/src/cmdeploy/nginx/nginx.conf.j2
@@ -117,10 +117,7 @@ http {
 
 	# Redirect www. to non-www
 	server {
-		listen 8443 ssl;
-		{% if not disable_ipv6 %}
-		listen [::]:8443 ssl;
-		{% endif %}
+		listen 127.0.0.1:8443 ssl;
 		server_name www.{{ config.domain_name }};
 		return 301 $scheme://{{ config.domain_name }}$request_uri;
 		access_log syslog:server=unix:/dev/log,facility=local7;


### PR DESCRIPTION
There was an additional 8443 bind for the www redirect that was overlooked.

Also added the Changelog entry