### PR TITLE
enforce encryption for in-server mails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## untagged
 
+- Enforce end-to-end encryption between local addresses 
+  ([#535](https://github.com/chatmail/server/pull/535))
+
 - Limit the bind for the HTTPS server on 8443 to 127.0.0.1 
   ([#522](https://github.com/chatmail/server/pull/522))
   ([#532](https://github.com/chatmail/server/pull/532))

--- a/chatmaild/src/chatmaild/echo.py
+++ b/chatmaild/src/chatmaild/echo.py
@@ -8,6 +8,7 @@ import logging
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 from deltachat_rpc_client import Bot, DeltaChat, EventType, Rpc, events
 
@@ -96,6 +97,10 @@ def main():
 
         if not bot.is_configured():
             bot.configure(addr, password)
+
+        # write invite link to working directory
+        invitelink = bot.account.get_qr_code()
+        Path("invite-link.txt").write_text(invitelink)
 
         bot.run_forever()
 

--- a/chatmaild/src/chatmaild/tests/plugin.py
+++ b/chatmaild/src/chatmaild/tests/plugin.py
@@ -72,9 +72,8 @@ def maildata(request):
     def maildata(name, from_addr, to_addr, subject="[...]"):
         # Using `.read_bytes().decode()` instead of `.read_text()` to preserve newlines.
         data = datadir.joinpath(name).read_bytes().decode()
-
         text = data.format(from_addr=from_addr, to_addr=to_addr, subject=subject)
-        return BytesParser(policy=policy.default).parsebytes(text.encode())
+        return BytesParser(policy=policy.SMTP).parsebytes(text.encode())
 
     return maildata
 

--- a/cmdeploy/src/cmdeploy/remote/rshell.py
+++ b/cmdeploy/src/cmdeploy/remote/rshell.py
@@ -14,3 +14,22 @@ def shell(command, fail_ok=False):
 def get_systemd_running():
     lines = shell("systemctl --type=service --state=running").split("\n")
     return [line for line in lines if line.startswith("  ")]
+
+
+def write_numbytes(path, num):
+    with open(path, "w") as f:
+        f.write("x" * num)
+
+
+def dovecot_recalc_quota(user):
+    shell(f"doveadm quota recalc -u {user}")
+    output = shell(f"doveadm quota get -u {user}")
+    #
+    # Quota name Type    Value  Limit                                              %
+    # User quota STORAGE     5 102400                                              0
+    # User quota MESSAGE     2      -                                              0
+    #
+    for line in output.split("\n"):
+        parts = line.split()
+        if parts[2] == "STORAGE":
+            return dict(value=int(parts[3]), limit=int(parts[4]), percent=int(parts[5]))

--- a/cmdeploy/src/cmdeploy/tests/online/test_1_basic.py
+++ b/cmdeploy/src/cmdeploy/tests/online/test_1_basic.py
@@ -116,9 +116,8 @@ def test_authenticated_from(cmsetup, maildata):
 
 @pytest.mark.parametrize("from_addr", ["fake@example.org", "fake@testrun.org"])
 def test_reject_missing_dkim(cmsetup, maildata, from_addr):
-    """Test that emails with missing or wrong DMARC, DKIM, and SPF entries are rejected."""
     recipient = cmsetup.gen_users(1)[0]
-    msg = maildata("plain.eml", from_addr=from_addr, to_addr=recipient.addr).as_string()
+    msg = maildata("encrypted.eml", from_addr=from_addr, to_addr=recipient.addr).as_string()
     with smtplib.SMTP(cmsetup.maildomain, 25) as s:
         with pytest.raises(smtplib.SMTPDataError, match="No valid DKIM signature"):
             s.sendmail(from_addr=from_addr, to_addrs=recipient.addr, msg=msg)

--- a/cmdeploy/src/cmdeploy/tests/online/test_2_deltachat.py
+++ b/cmdeploy/src/cmdeploy/tests/online/test_2_deltachat.py
@@ -169,13 +169,11 @@ def test_echobot(cmfactory, chatmail_config, lp, sshdomain):
     sshexec = SSHExec(sshdomain)
     command = "cat /var/lib/echobot/invite-link.txt"
     echo_invite_link = sshexec(call=rshell.shell, kwargs=dict(command=command))
-    ac.qr_setup_contact(echo_invite_link)
+    chat = ac.qr_setup_contact(echo_invite_link)
     ac._evtracker.wait_securejoin_joiner_progress(1000)
 
-
     # send message and check it gets replied back
-    lp.sec(f"Send message to echo@{chatmail_config.mail_domain}")
-    chat = ac.create_chat(f"echo@{chatmail_config.mail_domain}")
+    lp.sec(f"Send message to echobot")
     text = "hi, I hope you text me back"
     chat.send_text(text)
     lp.sec("Wait for reply from echobot")

--- a/cmdeploy/src/cmdeploy/tests/online/test_2_deltachat.py
+++ b/cmdeploy/src/cmdeploy/tests/online/test_2_deltachat.py
@@ -54,9 +54,7 @@ class TestEndToEndDeltaChat:
         """Test that a DC account can send a message to a second DC account
         on the same chat-mail instance."""
         ac1, ac2 = cmfactory.get_online_accounts(2)
-        chat = cmfactory.get_accepted_chat(ac1, ac2)
-
-        lp.sec("ac1: prepare and send text message to ac2")
+        chat = cmfactory.get_protected_chat(ac1, ac2)
         chat.send_text("message0")
 
         lp.sec("wait for ac2 to receive message")
@@ -69,7 +67,7 @@ class TestEndToEndDeltaChat:
         before quota is exceeded, and thus depends on the speed of the upload.
         """
         ac1, ac2 = cmfactory.get_online_accounts(2)
-        chat = cmfactory.get_accepted_chat(ac1, ac2)
+        chat = cmfactory.get_protected_chat(ac1, ac2)
 
         def parse_size_limit(limit: str) -> int:
             """Parse a size limit and return the number of bytes as integer.
@@ -172,7 +170,7 @@ def test_hide_senders_ip_address(cmfactory):
     assert ipaddress.ip_address(public_ip)
 
     user1, user2 = cmfactory.get_online_accounts(2)
-    chat = cmfactory.get_accepted_chat(user1, user2)
+    chat = cmfactory.get_protected_chat(user1, user2)
 
     chat.send_text("testing submission header cleanup")
     user2._evtracker.wait_next_incoming_message()

--- a/cmdeploy/src/cmdeploy/tests/online/test_2_deltachat.py
+++ b/cmdeploy/src/cmdeploy/tests/online/test_2_deltachat.py
@@ -1,5 +1,4 @@
 import ipaddress
-import random
 import re
 import time
 
@@ -64,13 +63,16 @@ class TestEndToEndDeltaChat:
         msg2 = ac2._evtracker.wait_next_incoming_message()
         assert msg2.text == "message0"
 
-    @pytest.mark.slow
-    def test_exceed_quota(self, cmfactory, lp, tmpdir, remote, chatmail_config):
+    def test_exceed_quota(
+        self, cmfactory, lp, tmpdir, remote, chatmail_config, sshdomain
+    ):
         """This is a very slow test as it needs to upload >100MB of mail data
         before quota is exceeded, and thus depends on the speed of the upload.
         """
         ac1, ac2 = cmfactory.get_online_accounts(2)
         chat = cmfactory.get_protected_chat(ac1, ac2)
+
+        user = ac2.get_config("configured_addr")
 
         def parse_size_limit(limit: str) -> int:
             """Parse a size limit and return the number of bytes as integer.
@@ -83,49 +85,27 @@ class TestEndToEndDeltaChat:
             return int(float(number) * units[unit])
 
         quota = parse_size_limit(chatmail_config.max_mailbox_size)
-        attachsize = 1 * 1024 * 1024
-        num_to_send = quota // attachsize + 2
-        lp.sec(f"ac1: send {num_to_send} large files to ac2")
-        lp.indent(f"per-user quota is assumed to be: {quota / (1024 * 1024)}MB")
-        alphanumeric = "abcdefghijklmnopqrstuvwxyz1234567890"
-        msgs = []
-        for i in range(num_to_send):
-            attachment = tmpdir / f"attachment{i}"
-            data = "".join(random.choice(alphanumeric) for i in range(1024))
-            with open(attachment, "w+") as f:
-                for j in range(attachsize // len(data)):
-                    f.write(data)
 
-            msg = chat.send_file(str(attachment))
-            msgs.append(msg)
-            lp.indent(f"Sent out msg {i}, size {attachsize / (1024 * 1024)}MB")
+        lp.sec(f"filling remote inbox for {user}")
+        fn = f"7743102289.M843172P2484002.c20,S={quota},W=2398:2,"
+        path = chatmail_config.mailboxes_dir.joinpath(user, "cur", fn)
+        sshexec = SSHExec(sshdomain)
+        sshexec(call=rshell.write_numbytes, kwargs=dict(path=str(path), num=120))
+        res = sshexec(call=rshell.dovecot_recalc_quota, kwargs=dict(user=user))
+        assert res["percent"] >= 100
 
-        lp.sec("ac2: check messages are arriving until quota is reached")
+        lp.sec("ac2: check quota is triggered")
 
-        addr = ac2.get_config("addr").lower()
-        saved_ok = 0
+        starting = True
         for line in remote.iter_output("journalctl -n0 -f -u dovecot"):
-            if addr not in line:
+            if starting:
+                chat.send_text("hello")
+                starting = False
+            if user not in line:
                 # print(line)
                 continue
-            if "quota" in line:
-                if "quota exceeded" in line:
-                    if saved_ok < num_to_send // 2:
-                        pytest.fail(
-                            f"quota exceeded too early: after {saved_ok} messages already"
-                        )
-                    lp.indent("good, message sending failed because quota was exceeded")
-                    return
-            if (
-                "stored mail into mailbox 'inbox'" in line
-                or "saved mail to inbox" in line
-            ):
-                saved_ok += 1
-                print(f"{saved_ok}: {line}")
-                if saved_ok >= num_to_send:
-                    break
-
-        pytest.fail("sending succeeded although messages should exceed quota")
+            if "quota exceeded" in line:
+                return
 
     def test_securejoin(self, cmfactory, lp, maildomain2):
         ac1 = cmfactory.new_online_configuring_account(cache=False)

--- a/cmdeploy/src/cmdeploy/tests/plugin.py
+++ b/cmdeploy/src/cmdeploy/tests/plugin.py
@@ -302,10 +302,12 @@ def cmfactory(request, gencreds, tmpdir, maildomain):
     pytest.importorskip("deltachat")
     from deltachat.testplugin import ACFactory
 
-    data = request.getfixturevalue("data")
-
     testproc = ChatmailTestProcess(request.config, maildomain, gencreds)
-    am = ACFactory(request=request, tmpdir=tmpdir, testprocess=testproc, data=data)
+
+    class Data:
+        def read_path(self, path):
+            return
+    am = ACFactory(request=request, tmpdir=tmpdir, testprocess=testproc, data=Data())
 
     # nb. a bit hacky
     # would probably be better if deltachat's test machinery grows native support


### PR DESCRIPTION
this also simplifies the quota-exceeded test to not transfer tons of data and rather trick doveadm-quota calculation into considering a user over-quota. 