### PR TITLE
cmdeploy: disable nsd so it doesn't block port 53

### DIFF
--- a/cmdeploy/src/cmdeploy/__init__.py
+++ b/cmdeploy/src/cmdeploy/__init__.py
@@ -587,6 +587,12 @@ def deploy_chatmail(config_path: Path, disable_mail: bool) -> None:
     # Run local DNS resolver `unbound`.
     # `resolvconf` takes care of setting up /etc/resolv.conf
     # to use 127.0.0.1 as the resolver.
+    systemd.service(
+        name="Disable nsd if it's running, so it doesn't block port 53",
+        service="nsd.service",
+        running=False,
+        enabled=False,
+    )
     apt.packages(
         name="Install unbound",
         packages=["unbound", "unbound-anchor", "dnsutils"],


### PR DESCRIPTION
oops, we never created an issue for this. But in some cases cmdeploy fails to install unbound because nsd is already running on port 53. I made sure that this PR also works if nsd isn't installed and the nsd service doesn't exist.